### PR TITLE
Compile using older mvn versions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
     </build>
 
     <properties>
-        <maven.compiler.source>1.5</maven.compiler.source>
-        <maven.compiler.target>1.5</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
     </properties>
     
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -13,5 +13,10 @@
     <build>
         <sourceDirectory>src/</sourceDirectory>
     </build>
+
+    <properties>
+        <maven.compiler.source>1.5</maven.compiler.source>
+        <maven.compiler.target>1.5</maven.compiler.target>
+    </properties>
     
 </project>


### PR DESCRIPTION
Default mvn on ubuntu LTS (14.04) is 3.0.5 which defaults source version to 1.3 and fails to build.